### PR TITLE
RVA-0000 | Bugfix - Change event subscription loop to fix the CPU usage problem

### DIFF
--- a/pulse/pulsar_wrapper.go
+++ b/pulse/pulsar_wrapper.go
@@ -2,9 +2,10 @@ package pulse
 
 import (
 	"context"
+	"time"
+
 	"github.com/apache/pulsar-client-go/pulsar"
 	"github.com/roava/bifrost"
-	"time"
 )
 
 type producerWrapper struct {

--- a/pulse/pulse_test.go
+++ b/pulse/pulse_test.go
@@ -2,14 +2,15 @@ package pulse
 
 import (
 	"context"
+	"log"
+	"testing"
+	"time"
+
 	"github.com/roava/bifrost"
 	"github.com/roava/bifrost/events"
 	"github.com/roava/bifrost/platform"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"log"
-	"testing"
-	"time"
 )
 
 func TestInit(t *testing.T) {


### PR DESCRIPTION
## Description
The usage of `for` and `select` on the pulsar subscribers is generating a CPU resource consumption bug.
Changing to use a for and range in the channel like what we have in the Pulsar docs solves the problem. 

Related documentation: https://pulsar.apache.org/docs/en/client-libraries-go/#how-to-use-consumer-listener

## Related Issue
TODO!

## Motivation and Context
When we start some of our micro-services locally, usually in Linux it are using a lot of CPU resources and heating up our computers.
If that happens in production will compromises our services.

## Test Coverage For This Change
<!-- Please describe in detail how you manually tested your changes, and where any automated test coverage was added/updated -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

## Screencasts

The problem:
![Screenshot from 2022-04-04 09-10-57](https://user-images.githubusercontent.com/855202/161844037-62ee5be1-c3a0-4798-ada5-d6e0475ec98a.png)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [ ] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] Modules dependencies have been updated; run `go mod tidy`.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `gofmt -s -w .`
  - [x] `go vet ./...`
